### PR TITLE
Fix boolean parsing in refstorage

### DIFF
--- a/src/store/globalstate.js
+++ b/src/store/globalstate.js
@@ -11,7 +11,14 @@ const parseType = (value, type) => {
     return +value
   }
   if (type === 'boolean') {
-    return !!JSON.parse(type)
+    if (typeof value === 'boolean') {
+      return value
+    }
+    try {
+      return !!JSON.parse(value)
+    } catch (e) {
+      return value === 'true'
+    }
   }
   return value
 }


### PR DESCRIPTION
## Summary
- fix boolean parsing when retrieving items from `refstorage`

## Testing
- `npm test` *(fails: Missing script)*