### PR TITLE
Fix boolean parsing in parseType

### DIFF
--- a/src/store/globalstate.js
+++ b/src/store/globalstate.js
@@ -11,7 +11,7 @@ const parseType = (value, type) => {
     return +value
   }
   if (type === 'boolean') {
-    return !!JSON.parse(type)
+    return !!JSON.parse(value)
   }
   return value
 }


### PR DESCRIPTION
## Summary
- fix boolean handling in `parseType`

## Testing
- `npm test` *(fails: Missing script `test`)*