### PR TITLE
Add vitest and fix scheduler timing bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "esbuild:install": " node ./node_modules/esbuild/install.js",
     "dev": "vite",
     "build": "vite build",
-    "serve": "vite preview"
+    "serve": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.7",
@@ -41,6 +42,7 @@
     "stylelint": "^16.19.1",
     "stylelint-config-standard": "^38.0.0",
     "typescript": "^5.4.5",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/plugins/scheduler.js
+++ b/src/plugins/scheduler.js
@@ -48,8 +48,6 @@ export async function collectionCreatedAt() {
   }
 }
 
-let dayCutof = getDayCutoff()
-
 let mToday = 0
 let mDayCutoff
 let mLrnQueue = LrnCardQueue.default
@@ -181,12 +179,12 @@ function getDayCutoff() {
   }
 
   const date = new Date()
-  date.setHours(rolloverTime)
+  date.setHours(rolloverTime, 0, 0, 0)
   if (date.getTime() < new Date().getTime()) {
     date.setDate(date.getDate() + 1)
   }
 
-  return date.getTime() / 1000
+  return date.getTime()
 }
 
 export async function answerCard(card, ease = 3) {
@@ -501,7 +499,7 @@ async function _lrnConf(card) {
   return await _newConf(card)
 }
 
-function _leftToday(delays, left, now = 0) {
+function _leftToday(delays, left, now = 0, cutoff = mDayCutoff ?? getDayCutoff()) {
   if (!now) {
     now = new Date().getTime()
   }
@@ -509,8 +507,8 @@ function _leftToday(delays, left, now = 0) {
   const delaysLength = delays.length
   let offset = Math.min(left, delaysLength)
   for (let i = 0; i < offset; i++) {
-    now += Math.floor((delaysLength - offset + i) * 60.0)
-    if (now > dayCutof) {
+    now += Math.floor((delaysLength - offset + i) * 60.0 * 1000)
+    if (now > cutoff) {
       break
     }
     ok = i
@@ -744,7 +742,7 @@ function _rescheduleGraduatingLapse(card, early) {
     card.ivl = (card.ivl ?? 0) + 1
   }
 
-  card.due += mToday + card.ivl
+  card.due = mToday + card.ivl
   card.queue = QueueType.Review
   card.type = CardType.Review
 }
@@ -836,3 +834,6 @@ export function addUndo(card) {
   }
   stackUndo.push(clonedCard)
 }
+
+// internal helpers exported for testing
+export { _leftToday, getDayCutoff }

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { _leftToday, getDayCutoff } from '../src/plugins/scheduler.js'
+
+describe('scheduler helpers', () => {
+  it('getDayCutoff returns milliseconds', () => {
+    const cutoff = getDayCutoff()
+    expect(typeof cutoff).toBe('number')
+    // should be in milliseconds (10^12 range)
+    expect(String(cutoff).length).toBeGreaterThan(10)
+  })
+
+  it('_leftToday respects day cutoff and uses ms', () => {
+    const delays = [1, 2, 3]
+    const left = 3
+    const now = 0
+    const cutoff = 2 * 60 * 1000 // two minutes from start
+    // With correct ms calculation we should only fit two steps (index 0 and 1)
+    const result = _leftToday(delays, left, now, cutoff)
+    expect(result).toBe(1)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
## Summary
- integrate Vitest and add test script
- expose helper functions from scheduler
- fix day cutoff and lapse scheduling logic
- add basic tests for scheduler logic

## Testing
- `npm run test` *(fails: vitest not found)*